### PR TITLE
フロントエンドのentitiesをcommon packageに分離

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@mantine/hooks": "^8.1.1",
     "@mantine/notifications": "^8.1.3",
     "@next/third-parties": "^15.3.5",
+    "@repo/common": "workspace:*",
     "@supabase/supabase-js": "^2.50.1",
     "@tailwindcss/postcss": "^4.1.10",
     "@vis.gl/react-google-maps": "^1.5.3",

--- a/apps/web/src/components/Navigations/ArtistDetailHeader.tsx
+++ b/apps/web/src/components/Navigations/ArtistDetailHeader.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Avatar, Button } from '@mantine/core';
+import type { User } from '@repo/common';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { FaChevronLeft } from 'react-icons/fa';
-import type { User } from '@/entities/user';
 
 type Props = {
   user: User;

--- a/apps/web/src/components/Navigations/DefaultHeader.tsx
+++ b/apps/web/src/components/Navigations/DefaultHeader.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Avatar, Button } from '@mantine/core';
+import type { User } from '@repo/common';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { FaChevronLeft } from 'react-icons/fa';
-import type { User } from '@/entities/user';
 
 type Props = {
   user: User;

--- a/apps/web/src/entities/artist.ts
+++ b/apps/web/src/entities/artist.ts
@@ -1,25 +1,4 @@
 import z from 'zod';
-import type { ArtistEvent } from './artistEvent';
-import type { UserArtistFollow } from './userArtistFollow';
-
-export type Artist = {
-  id: string;
-  artistName: string;
-  artistImageUrl: string;
-  artistDescription: string;
-  createdAt: Date;
-  updatedAt: Date;
-  genre: string;
-  ogpImageUrl: string;
-  region: string;
-  twitterId: string;
-  tiktokId: string;
-  instagramId: string;
-  youtubeUrl: string;
-  followers: UserArtistFollow[];
-  events: ArtistEvent[];
-};
-
 export const createArtistSchema = z.object({
   artistName: z.string().min(1, 'アーティスト名を入力してください'),
   artistImageUrl: z.string().min(1, 'アーティスト画像を選択してください'),

--- a/apps/web/src/entities/event.ts
+++ b/apps/web/src/entities/event.ts
@@ -1,27 +1,5 @@
+import type { Event } from '@repo/common';
 import z from 'zod';
-import type { ArtistEvent } from './artistEvent';
-
-export type Event = {
-  id: string;
-  eventName: string;
-  eventDescription: string;
-  eventImageUrl: string;
-  eventDate: Date;
-  ogpImageUrl: string;
-  openDateTime: Date;
-  startDateTime: Date;
-  locatePrefecture: string;
-  eventLocationName: string;
-  eventLocationAddress: string;
-  ticketReleaseDateTime: Date;
-  ticketPrice: number;
-  sameDayTicketPrice: number;
-  ticketUrl: string;
-  isNeedDrink: boolean;
-  drinkOption: string;
-  updatedAt: string;
-  artists: ArtistEvent[];
-};
 
 export const searchEventSchema = z.object({
   area: z.string(),

--- a/apps/web/src/entities/profile.ts
+++ b/apps/web/src/entities/profile.ts
@@ -1,16 +1,5 @@
 import z from 'zod';
 
-export type Profile = {
-  id: string;
-  userId: string;
-  userName: string;
-  userImageUrl: string;
-  userDescription: string;
-  mainActivityRegion: string; // 主な活動地域
-  createdAt: Date;
-  updatedAt: Date;
-};
-
 // 統一されたプロフィールフォーム型
 export const profileFormSchema = z.object({
   userImageUrl: z.string().nullable(),

--- a/apps/web/src/entities/user.ts
+++ b/apps/web/src/entities/user.ts
@@ -1,15 +1,4 @@
 import { z } from 'zod';
-import type { Profile } from './profile';
-import type { UserArtistFollow } from './userArtistFollow';
-
-export type User = {
-  id: string;
-  email: string;
-  createdAt: Date;
-  updatedAt: Date;
-  profile: Profile;
-  followingArtists: UserArtistFollow[];
-};
 
 export const signupUserSchema = z.object({
   email: z

--- a/apps/web/src/features/artist/components/ArtistDetailSection.tsx
+++ b/apps/web/src/features/artist/components/ArtistDetailSection.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { Badge, Button, Divider } from '@mantine/core';
+import type { Artist, User } from '@repo/common';
 import type React from 'react';
 import { FaLink, FaMapMarkerAlt } from 'react-icons/fa';
 import { FaXTwitter } from 'react-icons/fa6';
 import { LinkButton } from '@/components/Buttons/LinkButton';
 import { getGenreLabel, getRegionLabel } from '@/constants';
-import type { Artist } from '@/entities/artist';
-import type { User } from '@/entities/user';
 import { useFollow } from '@/features/artist/hooks/useFollow';
 import { useSnsShare } from '@/hooks/useSnsShare';
 

--- a/apps/web/src/features/artist/components/ArtistEventForm.tsx
+++ b/apps/web/src/features/artist/components/ArtistEventForm.tsx
@@ -1,15 +1,12 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Paper } from '@mantine/core';
+import type { Artist } from '@repo/common';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { LinkButton } from '@/components/Buttons/LinkButton';
-import {
-  type AddArtistEventSchemaType,
-  type Artist,
-  addArtistEventSchema,
-} from '@/entities/artist';
+import { type AddArtistEventSchemaType, addArtistEventSchema } from '@/entities/artist';
 import { useBackendToken } from '@/hooks/useBackendToken';
 import { useToast } from '@/hooks/useToast';
 import { createArtistEvent } from '@/service/artistEvent';

--- a/apps/web/src/features/artist/components/ArtistEventInput.tsx
+++ b/apps/web/src/features/artist/components/ArtistEventInput.tsx
@@ -1,9 +1,8 @@
 'use client';
 import { Badge, Button } from '@mantine/core';
+import type { Artist, Event } from '@repo/common';
 import { useState } from 'react';
 import { DebouncedInput } from '@/components/Inputs/DebouncedInput';
-import type { Artist } from '@/entities/artist';
-import type { Event } from '@/entities/event';
 import { EventSelectButton } from '@/features/artist/components/EventSelectButton';
 import { searchEvents } from '@/service/event';
 

--- a/apps/web/src/features/artist/components/ArtistListCard.tsx
+++ b/apps/web/src/features/artist/components/ArtistListCard.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { Button, Card, Image } from '@mantine/core';
+import type { Artist } from '@repo/common';
 import Link from 'next/link';
 import { DEFAULT_IMAGE_URL, getGenreLabel, getRegionLabel } from '@/constants';
-import type { Artist } from '@/entities/artist';
 
 type Props = {
   artist: Artist;

--- a/apps/web/src/features/artist/components/ArtistScheduleCalender.tsx
+++ b/apps/web/src/features/artist/components/ArtistScheduleCalender.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { Calendar } from '@mantine/dates';
 import { useMediaQuery } from '@mantine/hooks';
-import type { Artist } from '@/entities/artist';
+import type { Artist, Event } from '@repo/common';
 import { EventCard } from '@/features/artist/components/EventCard';
 import { useCalenderSchedule } from '@/features/artist/hooks/useCalenderSchedule';
 import dayjs from '@/libs/dayjs';

--- a/apps/web/src/features/artist/components/ArtistScheduleSection.tsx
+++ b/apps/web/src/features/artist/components/ArtistScheduleSection.tsx
@@ -1,9 +1,8 @@
 'use client';
 import { Button } from '@mantine/core';
+import type { Artist, User } from '@repo/common';
 import { FaCalendarAlt } from 'react-icons/fa';
 import { LinkButton } from '@/components/Buttons/LinkButton';
-import type { Artist } from '@/entities/artist';
-import type { User } from '@/entities/user';
 import { ArtistScheduleCalender } from '@/features/artist/components/ArtistScheduleCalender';
 import { useGoogleCalendarSync } from '@/features/artist/hooks/useGoogleCalendarSync';
 

--- a/apps/web/src/features/artist/components/ArtistSnsSection.tsx
+++ b/apps/web/src/features/artist/components/ArtistSnsSection.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { ActionIcon } from '@mantine/core';
+import type { Artist } from '@repo/common';
 import Link from 'next/link';
 import { FaInstagram, FaTiktok, FaXTwitter, FaYoutube } from 'react-icons/fa6';
 import { SNS_LINKS } from '@/constants';
-import type { Artist } from '@/entities/artist';
 
 type Props = {
   artist: Artist;

--- a/apps/web/src/features/artist/components/EditArtistForm.tsx
+++ b/apps/web/src/features/artist/components/EditArtistForm.tsx
@@ -2,13 +2,14 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button, Paper, Select, Textarea, TextInput } from '@mantine/core';
+import type { Artist } from '@repo/common';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { ImageInput } from '@/components/Inputs/ImageInput';
 import { ARTIST_GENRES, JAPAN_REGIONS, SUPABASE_BUCKETS, SUPABASE_UPLOAD_PATHS } from '@/constants';
-import { type Artist, type CreateArtistSchemaType, createArtistSchema } from '@/entities/artist';
+import { type CreateArtistSchemaType, createArtistSchema } from '@/entities/artist';
 import { useToast } from '@/hooks/useToast';
 import { createArtist, updateArtist } from '@/service/artist';
 

--- a/apps/web/src/features/artist/components/EventCard.tsx
+++ b/apps/web/src/features/artist/components/EventCard.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { Badge, Image } from '@mantine/core';
+import type { Event } from '@repo/common';
 import Link from 'next/link';
 import { FaMapMarkerAlt } from 'react-icons/fa';
 import { DEFAULT_IMAGE_URL, getAreaLabel } from '@/constants';
-import type { Event } from '@/entities/event';
 import dayjs from '@/libs/dayjs';
 
 type Props = {

--- a/apps/web/src/features/artist/components/EventSelectButton.tsx
+++ b/apps/web/src/features/artist/components/EventSelectButton.tsx
@@ -1,7 +1,7 @@
 import { Badge, Image } from '@mantine/core';
+import type { Event } from '@repo/common';
 import { FaCheck, FaMapMarkerAlt } from 'react-icons/fa';
 import { DEFAULT_IMAGE_URL, getAreaLabel } from '@/constants';
-import type { Event } from '@/entities/event';
 import dayjs from '@/libs/dayjs';
 
 type Props = {

--- a/apps/web/src/features/artist/components/NearestEventSection.tsx
+++ b/apps/web/src/features/artist/components/NearestEventSection.tsx
@@ -1,4 +1,4 @@
-import type { Artist } from '@/entities/artist';
+import type { Artist } from '@repo/common';
 import { EventCard } from '@/features/artist/components/EventCard';
 import dayjs from '@/libs/dayjs';
 

--- a/apps/web/src/features/artist/hooks/useArtists.ts
+++ b/apps/web/src/features/artist/hooks/useArtists.ts
@@ -1,5 +1,5 @@
+import type { Artist } from '@repo/common';
 import { useEffect, useState } from 'react';
-import type { Artist } from '@/entities/artist';
 import { getArtistListByQuery } from '@/service/artist';
 
 export const useArtists = (

--- a/apps/web/src/features/artist/hooks/useCalenderSchedule.ts
+++ b/apps/web/src/features/artist/hooks/useCalenderSchedule.ts
@@ -1,5 +1,5 @@
+import type { Artist } from '@repo/common';
 import { useEffect, useRef, useState } from 'react';
-import type { Artist } from '@/entities/artist';
 import type { GroupedEvents } from '@/entities/event';
 import dayjs from '@/libs/dayjs';
 

--- a/apps/web/src/features/artist/hooks/useFollowList.ts
+++ b/apps/web/src/features/artist/hooks/useFollowList.ts
@@ -1,6 +1,5 @@
+import type { Artist, User } from '@repo/common';
 import { useEffect, useState } from 'react';
-import type { Artist } from '@/entities/artist';
-import type { User } from '@/entities/user';
 import { useBackendToken } from '@/hooks/useBackendToken';
 import { useToast } from '@/hooks/useToast';
 import { getCurrentUserByBackendToken } from '@/service/user';

--- a/apps/web/src/features/artist/hooks/useGoogleCalendarSync.ts
+++ b/apps/web/src/features/artist/hooks/useGoogleCalendarSync.ts
@@ -1,8 +1,7 @@
 'use client';
 
+import type { Artist, GoogleCalendarEvent, TokenClient } from '@repo/common';
 import { useCallback, useEffect, useState } from 'react';
-import type { Artist } from '@/entities/artist';
-import type { GoogleCalendarEvent, TokenClient } from '@/entities/googleCalender';
 import { useToast } from '@/hooks/useToast';
 import dayjs from '@/libs/dayjs';
 import { convertEventToGoogleCalendar } from '@/libs/googleCalender';

--- a/apps/web/src/features/event/components/ArtistSelectButton.tsx
+++ b/apps/web/src/features/event/components/ArtistSelectButton.tsx
@@ -1,7 +1,7 @@
 import { Avatar } from '@mantine/core';
+import type { Artist } from '@repo/common';
 import { FaCheck } from 'react-icons/fa';
 import { DEFAULT_IMAGE_URL } from '@/constants';
-import type { Artist } from '@/entities/artist';
 
 type Props = {
   artist: Artist;

--- a/apps/web/src/features/event/components/EditEventForm.tsx
+++ b/apps/web/src/features/event/components/EditEventForm.tsx
@@ -1,10 +1,10 @@
 'use client';
+import type { Event } from '@repo/common';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { GoogleMapContainer } from '@/components/Container/GoogleMapContainer';
 import type {
   EditEventRequestType,
-  Event,
   FirstEditEventSchemaType,
   SecondEditEventSchemaType,
   ThirdEditEventSchemaType,

--- a/apps/web/src/features/event/components/EventArtistCard.tsx
+++ b/apps/web/src/features/event/components/EventArtistCard.tsx
@@ -1,7 +1,7 @@
 import { Avatar } from '@mantine/core';
+import type { Artist } from '@repo/common';
 import Link from 'next/link';
 import { DEFAULT_IMAGE_URL } from '@/constants';
-import type { Artist } from '@/entities/artist';
 
 type Props = {
   artist: Artist;

--- a/apps/web/src/features/event/components/EventArtistInput.tsx
+++ b/apps/web/src/features/event/components/EventArtistInput.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { Badge, Button } from '@mantine/core';
+import type { Artist } from '@repo/common';
 import { useEffect, useState } from 'react';
 import { FaDeleteLeft } from 'react-icons/fa6';
 import { DebouncedInput } from '@/components/Inputs/DebouncedInput';
-import type { Artist } from '@/entities/artist';
 import { ArtistSelectButton } from '@/features/event/components/ArtistSelectButton';
 import { getArtistListByIds, getArtistListByQuery } from '@/service/artist';
 

--- a/apps/web/src/features/event/components/EventArtistSection.tsx
+++ b/apps/web/src/features/event/components/EventArtistSection.tsx
@@ -1,4 +1,4 @@
-import type { Artist } from '@/entities/artist';
+import type { Artist } from '@repo/common';
 import { EventArtistCard } from '@/features/event/components/EventArtistCard';
 
 type Props = {

--- a/apps/web/src/features/event/components/EventDateSection.tsx
+++ b/apps/web/src/features/event/components/EventDateSection.tsx
@@ -1,4 +1,4 @@
-import type { Event } from '@/entities/event';
+import type { Event } from '@repo/common';
 import dayjs from '@/libs/dayjs';
 
 type Props = {

--- a/apps/web/src/features/event/components/EventDetailSection.tsx
+++ b/apps/web/src/features/event/components/EventDetailSection.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { Badge, Button, Divider } from '@mantine/core';
+import type { Event } from '@repo/common';
 import type { User } from 'next-auth';
 import type React from 'react';
 import { FaMapMarkerAlt } from 'react-icons/fa';
 import { FaLink, FaXTwitter } from 'react-icons/fa6';
 import { LinkButton } from '@/components/Buttons/LinkButton';
 import { getAreaLabel } from '@/constants';
-import type { Event } from '@/entities/event';
 import { useSnsShare } from '@/hooks/useSnsShare';
 
 type Props = {

--- a/apps/web/src/features/event/components/EventListCard.tsx
+++ b/apps/web/src/features/event/components/EventListCard.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { Badge, Image } from '@mantine/core';
+import type { Event } from '@repo/common';
 import Link from 'next/link';
 import { FaMapMarkerAlt } from 'react-icons/fa';
 import { DEFAULT_IMAGE_URL, getAreaLabel } from '@/constants';
-import type { Event } from '@/entities/event';
 import dayjs from '@/libs/dayjs';
 
 type Props = {

--- a/apps/web/src/features/event/components/EventLocationSection.tsx
+++ b/apps/web/src/features/event/components/EventLocationSection.tsx
@@ -1,7 +1,7 @@
 'use client';
+import type { Event } from '@repo/common';
 import { Map as GoogleMap, Marker, useApiIsLoaded } from '@vis.gl/react-google-maps';
 import { useEffect, useState } from 'react';
-import type { Event } from '@/entities/event';
 import type { GoogleMapGeocodeResult } from '@/entities/googleMap';
 
 type Props = {

--- a/apps/web/src/features/event/components/EventTicketSection.tsx
+++ b/apps/web/src/features/event/components/EventTicketSection.tsx
@@ -1,5 +1,5 @@
+import type { Event } from '@repo/common';
 import { LinkButton } from '@/components/Buttons/LinkButton';
-import type { Event } from '@/entities/event';
 import dayjs from '@/libs/dayjs';
 
 type Props = {

--- a/apps/web/src/features/event/hooks/useEvent.ts
+++ b/apps/web/src/features/event/hooks/useEvent.ts
@@ -1,5 +1,5 @@
+import type { Event } from '@repo/common';
 import { useEffect, useState } from 'react';
-import type { Event } from '@/entities/event';
 import { searchEvents } from '@/service/event';
 
 export const useEvents = (

--- a/apps/web/src/features/home/FollowingArtistsSection.tsx
+++ b/apps/web/src/features/home/FollowingArtistsSection.tsx
@@ -1,4 +1,4 @@
-import type { Artist } from '@/entities/artist';
+import type { Artist } from '@repo/common';
 import { ArtistCard } from '@/features/top/components/ArtistCard';
 
 type Props = {

--- a/apps/web/src/features/profile/components/EditProfileForm.tsx
+++ b/apps/web/src/features/profile/components/EditProfileForm.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import type { Profile } from '@repo/common';
 import { useEffect, useState } from 'react';
 import type {
   FirstProfileEditFormType,
-  Profile,
   ProfileFormType,
   SecondProfileEditFormType,
 } from '@/entities/profile';

--- a/apps/web/src/features/profile/components/ProfileInfo.tsx
+++ b/apps/web/src/features/profile/components/ProfileInfo.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Badge } from '@mantine/core';
+import type { Profile } from '@repo/common';
 import { FaMapMarkerAlt, FaUser } from 'react-icons/fa';
 import { DEFAULT_IMAGE_URL, getRegionLabel } from '@/constants';
-import type { Profile } from '@/entities/profile';
 
 type Props = {
   profile: Profile;

--- a/apps/web/src/features/top/components/ArtistCard.tsx
+++ b/apps/web/src/features/top/components/ArtistCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { Card, Image } from '@mantine/core';
+import type { Artist } from '@repo/common';
 import Link from 'next/link';
 import { DEFAULT_IMAGE_URL } from '@/constants';
-import type { Artist } from '@/entities/artist';
 
 type Props = {
   artist: Artist;

--- a/apps/web/src/features/top/components/EventCard.tsx
+++ b/apps/web/src/features/top/components/EventCard.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { Card, Image } from '@mantine/core';
+import type { Event } from '@repo/common';
 import Link from 'next/link';
 import { DEFAULT_IMAGE_URL } from '@/constants';
-import type { Event } from '@/entities/event';
 import dayjs from '@/libs/dayjs';
 
 type Props = {

--- a/apps/web/src/libs/googleCalender.ts
+++ b/apps/web/src/libs/googleCalender.ts
@@ -1,4 +1,4 @@
-import type { Event } from '@/entities/event';
+import type { Event } from '@repo/common';
 import type { GoogleCalendarEvent } from '@/entities/googleCalender';
 import dayjs from '@/libs/dayjs';
 

--- a/apps/web/src/service/artist.ts
+++ b/apps/web/src/service/artist.ts
@@ -1,4 +1,5 @@
-import type { Artist, CreateArtistSchemaType, UpdateArtistSchemaType } from '@/entities/artist';
+import type { Artist } from '@repo/common';
+import type { CreateArtistSchemaType, UpdateArtistSchemaType } from '@/entities/artist';
 
 export const createArtist = async (
   dto: CreateArtistSchemaType,

--- a/apps/web/src/service/event.ts
+++ b/apps/web/src/service/event.ts
@@ -1,4 +1,5 @@
-import type { EditEventRequestType, Event } from '@/entities/event';
+import type { Event } from '@repo/common';
+import type { EditEventRequestType } from '@/entities/event';
 
 export const createEvent = async (dto: EditEventRequestType): Promise<Event> => {
   const result = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/event`, {

--- a/apps/web/src/service/user.ts
+++ b/apps/web/src/service/user.ts
@@ -1,5 +1,5 @@
+import type { User } from '@repo/common';
 import { auth } from '@/auth';
-import type { User } from '@/entities/user';
 
 export const getCurrentUser = async (): Promise<User | null> => {
   const session = await auth();

--- a/apps/web/src/service/userArtistFollow.ts
+++ b/apps/web/src/service/userArtistFollow.ts
@@ -1,4 +1,4 @@
-import type { UserArtistFollow } from '@/entities/userArtistFollow';
+import type { UserArtistFollow } from '@repo/common';
 
 export const getUserArtistFollow = async (
   backendToken: string,

--- a/packages/common/.gitignore
+++ b/packages/common/.gitignore
@@ -1,0 +1,35 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# turbo
+.turbo
+
+# typescript
+*.tsbuildinfo

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@repo/common",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "scripts": {
+    "lint:ts": "tsc --noEmit",
+    "lint:biome": "biome check ./src"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/common/src/entities/Artist.ts
+++ b/packages/common/src/entities/Artist.ts
@@ -1,0 +1,20 @@
+import type { ArtistEvent } from './ArtistEvent';
+import type { UserArtistFollow } from './UserArtistFollow';
+
+export type Artist = {
+  id: string;
+  artistName: string;
+  artistImageUrl: string;
+  artistDescription: string;
+  createdAt: Date;
+  updatedAt: Date;
+  genre: string;
+  ogpImageUrl: string;
+  region: string;
+  twitterId: string;
+  tiktokId: string;
+  instagramId: string;
+  youtubeUrl: string;
+  followers: UserArtistFollow[];
+  events: ArtistEvent[];
+};

--- a/packages/common/src/entities/ArtistEvent.ts
+++ b/packages/common/src/entities/ArtistEvent.ts
@@ -1,5 +1,5 @@
-import type { Artist } from './artist';
-import type { Event } from './event';
+import type { Artist } from './Artist';
+import type { Event } from './Event';
 
 export type ArtistEvent = {
   id: string;

--- a/packages/common/src/entities/Event.ts
+++ b/packages/common/src/entities/Event.ts
@@ -1,0 +1,23 @@
+import type { ArtistEvent } from './ArtistEvent';
+
+export type Event = {
+  id: string;
+  eventName: string;
+  eventDescription: string;
+  eventImageUrl: string;
+  eventDate: Date;
+  ogpImageUrl: string;
+  openDateTime: Date;
+  startDateTime: Date;
+  locatePrefecture: string;
+  eventLocationName: string;
+  eventLocationAddress: string;
+  ticketReleaseDateTime: Date;
+  ticketPrice: number;
+  sameDayTicketPrice: number;
+  ticketUrl: string;
+  isNeedDrink: boolean;
+  drinkOption: string;
+  updatedAt: string;
+  artists: ArtistEvent[];
+};

--- a/packages/common/src/entities/GoogleCalender.ts
+++ b/packages/common/src/entities/GoogleCalender.ts
@@ -1,0 +1,39 @@
+export type TokenClient = {
+  requestAccessToken: (options?: { prompt?: string }) => void;
+};
+
+export type GoogleCalendarEvent = {
+  summary: string;
+  description?: string;
+  location?: string;
+  start: {
+    dateTime?: string;
+    date?: string;
+    timeZone?: string;
+  };
+  end: {
+    dateTime?: string;
+    date?: string;
+    timeZone?: string;
+  };
+  reminders?: {
+    useDefault: boolean;
+    overrides?: Array<{
+      method: string;
+      minutes: number;
+    }>;
+  };
+};
+
+export type GoogleCalendarSyncResult = {
+  success: boolean;
+  message: string;
+  syncedEvents?: number;
+};
+
+export type GoogleCalendarConfig = {
+  clientId: string;
+  apiKey: string;
+  scope: string;
+  discoveryDocs: string[];
+};

--- a/packages/common/src/entities/Profile.ts
+++ b/packages/common/src/entities/Profile.ts
@@ -1,0 +1,10 @@
+export type Profile = {
+  id: string;
+  userId: string;
+  userName: string;
+  userImageUrl: string;
+  userDescription: string;
+  mainActivityRegion: string; // 主な活動地域
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/packages/common/src/entities/User.ts
+++ b/packages/common/src/entities/User.ts
@@ -1,0 +1,11 @@
+import type { Profile } from './Profile';
+import type { UserArtistFollow } from './UserArtistFollow';
+
+export type User = {
+  id: string;
+  email: string;
+  createdAt: Date;
+  updatedAt: Date;
+  profile: Profile;
+  followingArtists: UserArtistFollow[];
+};

--- a/packages/common/src/entities/UserArtistFollow.ts
+++ b/packages/common/src/entities/UserArtistFollow.ts
@@ -1,5 +1,5 @@
-import type { Artist } from './artist';
-import type { User } from './user';
+import type { Artist } from './Artist';
+import type { User } from './User';
 
 export type UserArtistFollow = {
   id: string;

--- a/packages/common/src/entities/index.ts
+++ b/packages/common/src/entities/index.ts
@@ -1,0 +1,7 @@
+export * from './Artist';
+export * from './ArtistEvent';
+export * from './Event';
+export * from './GoogleCalender';
+export * from './Profile';
+export * from './User';
+export * from './UserArtistFollow';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,1 @@
+export * from './entities/index';

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@next/third-parties':
         specifier: ^15.3.5
         version: 15.3.5(next@15.3.3)(react@19.1.0)
+      '@repo/common':
+        specifier: workspace:*
+        version: link:../../packages/common
       '@supabase/supabase-js':
         specifier: ^2.50.1
         version: 2.50.1(ws@8.18.2)
@@ -157,6 +160,15 @@ importers:
       typescript:
         specifier: 5.8.2
         version: 5.8.2
+
+  packages/common:
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      typescript:
+        specifier: ^5.6.3
+        version: 5.8.3
 
   packages/typescript-config: {}
 


### PR DESCRIPTION
## 概要
entitiesをcommon packageに移設しました
再利用性が高まりました